### PR TITLE
Added a delete feature to assets

### DIFF
--- a/app/controllers/ckeditor_controller.rb
+++ b/app/controllers/ckeditor_controller.rb
@@ -59,6 +59,13 @@ class CkeditorController < ApplicationController
     end
   end
 
+  # DELETE /ckeditor/:id 
+  def destroy
+    @asset = Ckeditor::Asset.find(params[:id])
+    @asset.destroy
+    redirect_to request.referrer
+  end
+
   private
     
     def swf_options

--- a/app/views/ckeditor/_asset.html.erb
+++ b/app/views/ckeditor/_asset.html.erb
@@ -13,3 +13,4 @@
    <div class="FCKFileDate"><%= asset.format_created_at %></div>
    <div class="FCKFileSize"><%= number_to_human_size(asset.size, :precision => 2) %></div>
 </div>
+<%= link_to('&nbsp;', url_for(:controller => 'ckeditor', :action => 'destroy', :id => asset.id), :class => 'FCKFileDelete') %>

--- a/app/views/ckeditor/_asset.html.erb
+++ b/app/views/ckeditor/_asset.html.erb
@@ -13,4 +13,4 @@
    <div class="FCKFileDate"><%= asset.format_created_at %></div>
    <div class="FCKFileSize"><%= number_to_human_size(asset.size, :precision => 2) %></div>
 </div>
-<%= link_to('&nbsp;', url_for(:controller => 'ckeditor', :action => 'destroy', :id => asset.id), :class => 'FCKFileDelete') %>
+<%= link_to('&nbsp;', url_for(:controller => 'ckeditor', :action => 'destroy', :id => asset.id), :method => :delete, :class => 'FCKFileDelete') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ ActionController::Routing::Routes.draw do |map|
   map.connect 'ckeditor/images', :controller => 'ckeditor', :action => 'images'
   map.connect 'ckeditor/files',  :controller => 'ckeditor', :action => 'files'
   map.connect 'ckeditor/create/:kind', :controller => 'ckeditor', :action => 'create'
+  map.connect 'ckeditor/:id', :controller => 'ckeditor', :action => 'destroy', :conditions => {:method => :delete}
 end

--- a/generators/ckeditor_install/templates/ckeditor/css/ckfinder.css
+++ b/generators/ckeditor_install/templates/ckeditor/css/ckfinder.css
@@ -82,6 +82,18 @@ td.FCKFileSize
 	display: none;
 }
 
+a.FCKFileDelete { 
+  float:left;
+  background-image:url('/javascripts/ckeditor/images/cancelbutton.gif');
+	background-repeat: no-repeat;
+  background-position:-14px 0;
+  width:14px;
+}
+
+a.FCKFileDelete:hover {
+  background-position:0 0;
+}
+
 .FCKThumbTools
 {
 	padding: 2px;


### PR DESCRIPTION
I added a destroy action in CkeditorController, added a delete link in the ckeditor/_asset.html.erb view. It feels very bland and truthfully like I didn't do much of anything. Perhaps you had a reason for leaving this feature out. Either way your more than welcome to take my changes as is, leave them to my own fork or hack them into something more exciting.
