### PR TITLE
[Rails3] Fix production bug

### DIFF
--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -52,7 +52,7 @@ module Ckeditor
   
   # Get the image class from the image reference object.
   def self.image_model
-    if self.class_variables.include?(:@@image_model_ref)
+    if self.class_variables.include?('@@image_model_ref')
       @@image_model_ref.get 
     else
       self.file_manager_image_model = "Ckeditor::Picture"
@@ -67,7 +67,7 @@ module Ckeditor
   
   # Get the file class from the file reference object.
   def self.file_model
-    if self.class_variables.include?(:@@file_model_ref)
+    if self.class_variables.include?('@@file_model_ref')
       @@file_model_ref.get 
     else
       self.file_manager_file_model = "Ckeditor::AttachmentFile"


### PR DESCRIPTION
When you change default values for file_manager_image_model and file_manager_file_model in config file it didn't work in production env because Ckeditor.image_model and Ckeditor.file_model always return default values.
To fix this you should replace symbol to string during model_ref check.
