### PR TITLE
Fixed IE bug that stopped the file browser from working

### DIFF
--- a/generators/ckeditor_install/templates/ckeditor/swfupload/fileprogress.js
+++ b/generators/ckeditor_install/templates/ckeditor/swfupload/fileprogress.js
@@ -115,15 +115,9 @@ var Button = new Class({
     
     this.element.appendChild(table);
     
-    this.element.addEvents({
-          'mouseover': function(){
-              this.className = "TB_Button_Off_Over"
-          },
-          'mouseout': function(){
-              this.className = "TB_Button"
-          },
-          'click': this.callback.bind(this)
-    });
+    this.element.onclick = this.callback.bind(this);
+	this.element.onmouseover = function addButtonHover() { this.className = "TB_Button_Off_Over"; }
+	this.element.onmouseout = function removeButtonHover() { this.className = "TB_Button"; }
   }
 });
 


### PR DESCRIPTION
The upload / refresh buttons do not show up when trying to upload new photos in IE8.

Here is the JS error:

Webpage error details

User Agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)
Timestamp: Mon, 10 Jan 2011 20:56:06 UTC

Message: Object doesn't support this property or method
Line: 118
Char: 5
Code: 0
URI: http://192.168.179.1:3000/javascripts/ckeditor/swfupload/fileprogress.js
