### PR TITLE
Made it possible to pass ckeditor_options from the helper (to customize per-instance browseURLs)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -103,6 +103,7 @@ FormBuilder helper for more usefully:
   :swf_params   # SWFUpload additional params (Hash)
   :id           # textarea DOM element id
   :index        # element id index 
+  :ckeditor_options # A hash allowing you to change filebrowserBrowseUrl, etc
 
 For configure ckeditor default options check:
   public/javascripts/ckeditor/config.js

--- a/lib/ckeditor/view_helper.rb
+++ b/lib/ckeditor/view_helper.rb
@@ -34,18 +34,19 @@ module Ckeditor
       textarea_options[:class] = (options.delete(:class) || 'editor').to_s
       textarea_options[:style] = "width:#{width};height:#{height}"
       
-      ckeditor_options = {:width => width, :height => height }
+      ckeditor_options = {:width => width, :height => height }.
+        merge(options.delete(:ckeditor_options)||{})
       ckeditor_options[:language] = (options.delete(:language) || I18n.locale).to_s
       ckeditor_options[:toolbar]  = options.delete(:toolbar) if options[:toolbar]
       ckeditor_options[:skin]     = options.delete(:skin) if options[:skin]
       
       ckeditor_options[:swf_params] = options.delete(:swf_params) if options[:swf_params]
       
-      ckeditor_options[:filebrowserBrowseUrl] = Ckeditor.file_manager_uri
-      ckeditor_options[:filebrowserUploadUrl] = Ckeditor.file_manager_upload_uri
+      ckeditor_options[:filebrowserBrowseUrl] ||= Ckeditor.file_manager_uri
+      ckeditor_options[:filebrowserUploadUrl] ||= Ckeditor.file_manager_upload_uri
       
-      ckeditor_options[:filebrowserImageBrowseUrl] = Ckeditor.file_manager_image_uri
-      ckeditor_options[:filebrowserImageUploadUrl] = Ckeditor.file_manager_image_upload_uri
+      ckeditor_options[:filebrowserImageBrowseUrl] ||= Ckeditor.file_manager_image_uri
+      ckeditor_options[:filebrowserImageUploadUrl] ||= Ckeditor.file_manager_image_upload_uri
       
       output_buffer = ActiveSupport::SafeBuffer.new
         


### PR DESCRIPTION
Please merge this commit: 77a9645cd41972dae21f9e1c47c6809de5f08da0

This makes it possible to use different "Browse Server" browsers in different parts of the same app.

Thanks,

Clifford Heath.
