### PR TITLE
The way how rails-ckeditor is initialized resets other plugins hooks in ActionHelpers

### DIFF
--- a/lib/ckeditor/view_helper.rb
+++ b/lib/ckeditor/view_helper.rb
@@ -1,7 +1,8 @@
 module Ckeditor
   module ViewHelper
-    include ActionView::Helpers
-    
+    include ActionView::Helpers::JavaScriptHelper
+    include ActionView::Helpers::TagHelper 
+
     # Ckeditor helper:
     # <%= ckeditor_textarea("object", "field", :width => '100%', :height => '200px') %>
     #


### PR DESCRIPTION
The leads to interoperability problems with other gems/plugins. For example with dynamic_form.
