### PR TITLE
Ckeditor.file_model and Ruby 1.9

### DIFF
--- a/lib/ckeditor.rb
+++ b/lib/ckeditor.rb
@@ -73,7 +73,7 @@ module Ckeditor
   
   # Get the file class from the file reference object.
   def self.file_model
-    if self.class_variables.include?('@@file_model_ref')
+    if self.class_variable_defined?('@@file_model_ref')
       @@file_model_ref.get 
     else
       self.file_manager_file_model = "Ckeditor::AttachmentFile"


### PR DESCRIPTION
While dealing with not working file attachment browser I've decided to rename `AttachmentFile` model to `Attachment`. Started project and realized Ckeditor still trying to use `AttachmentFile` model.

After inspecting `Ckeditor.file_model` method I've figured out Ruby 1.9 (p180) method `Module.class_variables` returns an array of symbols, while Ruby 1.8 returns an array of strings.

`Module.class_variable_defined?` works both for 1.9 and 1.8 so this patch fixes the issue.
