### PR TITLE
Comment the line that deletes the value from the options hash

### DIFF
--- a/lib/ckeditor/view_helper.rb
+++ b/lib/ckeditor/view_helper.rb
@@ -21,7 +21,7 @@ module Ckeditor
       var ||= @template.instance_variable_get("@#{object}")
       
       value = var.send(field.to_sym) if var
-      value ||= options.delete(:value) || ""
+      #value ||= options.delete(:value) || ""
       
       element_id = options.delete(:id) || ckeditor_element_id(object, field, options.delete(:index))
       width  = options.delete(:width) || '100%'


### PR DESCRIPTION
ckeditor_textarea(object, attribute, :width => '100%', :height => '200px', :value => "please enter text")

the value should appear in the textarea but it doesn't. This is because the value is deleted from the :options hash. Commenting the line fixes it.

view_helper.rb, around line 24

 value = var.send(field.to_sym) if var
 value ||= options.delete(:value) || ""  # needs to be commented out.

However, the value will override the value from the object!

in /var/lib/gems/1.8/gems/actionpack-3.0.4/lib/action_view/helpers/form_helper.rb
around line 951, we find this:
content_tag("textarea", html_escape(options.delete('value') || value_before_type_cast(object)), options)

this has the nasty side effect, that :options['value'] will override any value from the object, thus always displaying 'enter some text here'. This is NOT good and I think that is why the value is stripped and not used.

But for those who don't use the object, like in 

ckeditor_textarea(nil, attribute, :width => '100%', :height => '200px', :value => "please enter text" || object.attribute )

the passing of the value is essential.

I think in ActionView, this needs to be changed:

content_tag("textarea", value_before_type_cast(object) || html_escape(options.delete('value') ), options)

becasue why would an external value always overrule the objects value??

Cheers
ace
