### PR TITLE
Comment the line that deletes the value from the options hash

### DIFF
--- a/lib/ckeditor/view_helper.rb
+++ b/lib/ckeditor/view_helper.rb
@@ -22,7 +22,7 @@ module Ckeditor
       var ||= @template.instance_variable_get("@#{object}")
       
       value = var.send(field.to_sym) if var
-      value ||= options.delete(:value) || ""
+#      value ||= options.delete(:value) || ""
       
       element_id = options.delete(:id) || ckeditor_element_id(object, field, options.delete(:index))
       width  = options.delete(:width) || '100%'


### PR DESCRIPTION
Dear, 
ckeditor_textarea(object, attribute, :width => '100%', :height => '200px', :value => "please enter text")

the value should appear in the textarea but it doesn't. This is because the value is deleted from the :options hash. Commenting the line fixes it.

view_helper.rb, around line 24

value = var.send(field.to_sym) if var
value ||= options.delete(:value) || "" # needs to be commented out.

However, the value will override the value from the object!

in /var/lib/gems/1.8/gems/actionpack-3.0.4/lib/action_view/helpers/form_helper.rb
around line 951, we find this:
content_tag("textarea", html_escape(options.delete('value') || value_before_type_cast(object)), options)

this has the nasty side effect, that :options['value'] will override any value from the object, thus always displaying 'enter some text here'. This is NOT good and I think that is why the value is stripped and not used.

But for those who don't use the object, like in

ckeditor_textarea(nil, attribute, :width => '100%', :height => '200px', :value => "please enter text" || object.attribute )

the passing of the value is essential.

I think in ActionView, this needs to be changed:

content_tag("textarea", value_before_type_cast(object) || html_escape(options.delete('value') ), options)

becasue why would an external value always overrule the objects value??

Cheers
ace

Previous text

In my project,  I was using text_area_tag to generate my text areas.

text_area_tag attribute, object[attribute], :class => 'attribute_text_area'

But in rails-ckeditor, it is using text_area:

ckeditor_textarea(object, attribute, :width => '100%', :height => '200px' )

text_area and text_area_tag work differently, in that in text_ares, the input name will be object[attribute], like person[name], but in text_area_tag, it's just 'name'... this wasn't a problem because I make the object nil, an

ckeditor_textarea(nil, attribute, :width => '100%', :height => '200px')

this works, except that the value of the attribute is not passed to ckeditor.

I thought, after looking at the code for quite a while, that I could pass in an option with the value, like so:

ckeditor_textarea(nil, attribute, :width => '100%', :height => '200px', :value => object[attribute] )

But, in view_helper.rb, around line 24, this happens:

 value = var.send(field.to_sym) if var
 value ||= options.delete(:value) || ""

This means, the value is stripped out of the options Hash, and is transferred to the 'value' variable. That variable is not used, further down, around line 52:

output_buffer << ActionView::Base::InstanceTag.new(object, field, self, var).to_text_area_tag(textarea_options.merge(options))

This results in the value being lost. Of course, if the object wasn't nil, the value of the attribute is picked up later, but in my project it just is lost.

in /var/lib/gems/1.8/gems/actionpack-3.0.4/lib/action_view/helpers/form_helper.rb
around line 951, we find this:

content_tag("textarea", html_escape(options.delete('value') || value_before_type_cast(object)), options)

It means that if the object is not nil, and the options Hash does not contain :value, it will go to value_before_type_cast(object)), which will normally retrieve the attribute value. In my case, it doesn't and I wanted to get it from options: html_escape(options.delete('value')

My 'fix' is to comment the line
value ||= options.delete(:value) || "" in view_helper.rb around line 24.

 value = var.send(field.to_sym) if var
 # value ||= options.delete(:value) || ""

This because value isn't used anywhere, as far as i can see.
Now the options Hash has :value and it is used in form_helper, and it looks okay (didn't try any file uploading, just plain html editing.)
